### PR TITLE
Make language option case-insensitive

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -15,17 +15,20 @@ const { LANGUAGES } = require( './constants' );
 /**
  * @desc Highlight code in ANSI color format.
  * @param { string } str - code (text)
- * @param { string } laguage - language of the code (`null` if code has no language)
+ * @param { string } language - language of the code (`null` if code has no language)
  */
-const stringToAnsi = exports.stringToAnsi = ( str, laguage ) => {
+const stringToAnsi = exports.stringToAnsi = ( str, language ) => {
+    
+    // accept case-insensitive language
+    language = language.toLowerCase();
 
     // if `language` is not supported, return `str` back without syntax highlighting
-    if( ! _.includes( _.values( LANGUAGES ), laguage ) ) {
+    if( ! _.includes( _.values( LANGUAGES ), language ) ) {
         return str;
     }
 
     // highlight `str` using `emphasize` package in ANSI color format
-    const { value } = emphasize.highlight( laguage, str );
+    const { value } = emphasize.highlight( language, str );
 
     // return ANSI formatted string
     return value;


### PR DESCRIPTION
Simply makes the language parameter lowercase.

I also changed `laguage` to `language` because it looks like a typo. It's a very consistent typo though, so maybe you had a reason for spelling it like that?